### PR TITLE
Allow placing `ref` declarations before lifecycle hooks

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,21 +135,19 @@ module.exports = {
       }
     ],
     "react/sort-comp": [
-      "error",
+      2,
       {
         "order": [
-          "type-annotations",
           "static-methods",
           "instance-variables",
+          "getters",
+          "setters",
           "lifecycle",
           "everything-else",
           "rendering"
         ],
         "groups": {
-          "rendering": [
-            "/^render.+$/",
-            "render"
-          ]
+          "rendering": ["render", "/^render.+$/"]
         }
       }
     ],

--- a/index.js
+++ b/index.js
@@ -140,6 +140,7 @@ module.exports = {
         "order": [
           "type-annotations",
           "static-methods",
+          "instance-variables",
           "lifecycle",
           "everything-else",
           "rendering"


### PR DESCRIPTION
### Notes
- This change has been made due to [this](https://github.com/Hipo/moku-web/pull/45#discussion_r295383969) conversation.