### PR TITLE
Update rules according to `hipo-frontend-project-starter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,4 @@ Set your eslint config to:
   "extends": ["@hipo/eslint-config-react"]
 }
 ```
+**FOR JS USERS:** If you are using JS in your project, you may want to add `react/prop-types:"error"` to your eslint config.

--- a/index.js
+++ b/index.js
@@ -148,7 +148,7 @@ module.exports = {
       "error",
       {
         "props": "always",
-        "children": "ignore"
+        "children": "always"
       }
     ],
     "react/jsx-sort-props": [

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ module.exports = {
     ],
     "react/forbid-foreign-prop-types": "error",
     "react/no-access-state-in-setstate": "error",
-    "react/no-array-index-key": "error",
+    "react/no-array-index-key": "warn",
     "react/no-children-prop": "error",
     "react/no-danger": "error",
     "react/no-danger-with-children": "error",

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@ module.exports = {
         "allowRequiredDefaults": false
       }
     ],
-    "react/destructuring-assignment": ["warn", "always"],
     "react/forbid-component-props": "off",
     "react/forbid-dom-props": "off",
     "react/forbid-elements": "off",

--- a/index.js
+++ b/index.js
@@ -110,9 +110,9 @@ module.exports = {
     ],
     "react/jsx-equals-spacing": ["error", "never"],
     "react/jsx-filename-extension": [
-      "error",
+      "warn",
       {
-        "extensions": [".jsx", ".tsx"]
+        extensions: [".jsx", ".tsx"]
       }
     ],
     "react/jsx-first-prop-new-line": ["error", "never"],

--- a/index.js
+++ b/index.js
@@ -28,7 +28,6 @@ module.exports = {
     "react/no-direct-mutation-state": "error",
     "react/no-find-dom-node": "error",
     "react/no-is-mounted": "error",
-    "react/no-multi-comp": "error",
     "react/no-multi-comp": [
       "error",
       {

--- a/index.js
+++ b/index.js
@@ -47,7 +47,6 @@ module.exports = {
     "react/no-will-update-set-state": "error",
     "react/prefer-es6-class": ["error", "always"],
     "react/prefer-stateless-function": "off",
-    "react/prop-types": "error",
     "react/react-in-jsx-scope": "error",
     "react/require-default-props": "off",
     "react/require-render-return": "error",

--- a/index.js
+++ b/index.js
@@ -115,13 +115,6 @@ module.exports = {
       }
     ],
     "react/jsx-first-prop-new-line": ["error", "never"],
-    "react/jsx-handler-names": [
-      "error",
-      {
-        "eventHandlerPrefix": "handle",
-        "eventHandlerPropPrefix": "on"
-      }
-    ],
     "react/jsx-indent": ["error", 2],
     "react/jsx-indent-props": "off",
     "react/jsx-key": "error",


### PR DESCRIPTION
* Turn off `react/prop-types`, `react/jsx-handler-names`,  `react/destructuring-assignment` rules by deleting them
* Remove duplicate `react/no-multi-comp` rule
* Update `react/jsx-filename-extension` rule 
    * Add `.tsx` extension
    * Give warning instead of error

[hipo-frontend-project-starter eslint rules](https://github.com/Hipo/hipo-frontend-project-starter/blob/master/.eslintrc.js)
